### PR TITLE
cellSupportsAnnotations for error graph

### DIFF
--- a/ui/src/loudml/CHANGELOG.md
+++ b/ui/src/loudml/CHANGELOG.md
@@ -1,0 +1,26 @@
+## v1.6.1 [2018-08-02]
+
+### Features
+
+1.  [#3](https://github.com/regel/chronograf/pull/3): About panel
+
+### UI Improvements
+
+1.  [#8](https://github.com/regel/chronograf/pull/8): visit loudml.io question mark
+1.  [#6](https://github.com/regel/chronograf/pull/6): resize loud ML notification icon
+
+### Bug Fixes
+
+1.  [#9](https://github.com/regel/chronograf/pull/9): database match for dashboard
+1.  [#5](https://github.com/regel/chronograf/pull/5): cloned model is not running
+
+## v1.4.3 [2018-03-27]
+
+### Features
+
+1.  [#2](https://github.com/regel/chronograf/pull/2): compute database & source for dashboard
+1.  [#1](https://github.com/regel/chronograf/pull/1): Implement proxy to LoudML into Chronograf server
+
+### Release Notes
+
+This is the initial alpha release of Chronograf 1.4 + LoudML extension 

--- a/ui/src/loudml/CHANGELOG.md
+++ b/ui/src/loudml/CHANGELOG.md
@@ -3,23 +3,24 @@
 ### Features
 
 1.  [#3](https://github.com/regel/chronograf/pull/3): About panel
+1.  [#17](https://github.com/regel/chronograf/pull/17): cellSupportsAnnotations for error graph
 
 ### UI Improvements
 
-1.  [#8](https://github.com/regel/chronograf/pull/8): visit loudml.io question mark
 1.  [#6](https://github.com/regel/chronograf/pull/6): resize loud ML notification icon
+1.  [#8](https://github.com/regel/chronograf/pull/8): visit loudml.io question mark
 
 ### Bug Fixes
 
-1.  [#9](https://github.com/regel/chronograf/pull/9): database match for dashboard
 1.  [#5](https://github.com/regel/chronograf/pull/5): cloned model is not running
+1.  [#9](https://github.com/regel/chronograf/pull/9): database match for dashboard
 
 ## v1.4.3 [2018-03-27]
 
 ### Features
 
-1.  [#2](https://github.com/regel/chronograf/pull/2): compute database & source for dashboard
 1.  [#1](https://github.com/regel/chronograf/pull/1): Implement proxy to LoudML into Chronograf server
+1.  [#2](https://github.com/regel/chronograf/pull/2): compute database & source for dashboard
 
 ### Release Notes
 

--- a/ui/src/shared/constants/index.tsx
+++ b/ui/src/shared/constants/index.tsx
@@ -473,7 +473,7 @@ export const cellSupportsAnnotations = cellType => {
     CellType.Line,
     CellType.Stacked,
     CellType.StepPlot,
-    // CellType.Error,
+    CellType.Error,
   ]
   return !!supportedTypes.find(type => type === cellType)
 }


### PR DESCRIPTION
Closes #13 

_What was the problem?_
No annotation support for error graph
_What was the solution?_
Add error graph type to cells supporting annotations

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass (manual)
