### PR TITLE
normalize span for 1-Click ML

### DIFF
--- a/ui/src/loudml/CHANGELOG.md
+++ b/ui/src/loudml/CHANGELOG.md
@@ -7,6 +7,7 @@
 1.  [#23](https://github.com/regel/chronograf/pull/23): Scores and Transform settings in Feature panel
 1.  [#24](https://github.com/regel/chronograf/pull/24): Datasink
 1.  [#28](https://github.com/regel/chronograf/pull/28): Unserialized Features in model
+1.  [#35](https://github.com/regel/chronograf/pull/35): normalize span for 1-Click ML
 
 ### UI Improvements
 

--- a/ui/src/loudml/components/OneClickML.js
+++ b/ui/src/loudml/components/OneClickML.js
@@ -14,6 +14,7 @@ import {createHook} from 'src/loudml/utils/hook'
 import {
     normalizeInterval,
     normalizeFeatureDefault,
+    normalizeSpan,
 } from 'src/loudml/utils/model'
 import {
     createModel,
@@ -204,6 +205,7 @@ class OneClickML extends Component {
             max_evals: 10,
             name: this.name,
             interval: normalizeInterval(time),
+            span: normalizeSpan(time),
             default_datasource: datasource,
             bucket_interval: time,
             features: fields.map(

--- a/ui/src/loudml/utils/model.js
+++ b/ui/src/loudml/utils/model.js
@@ -1,55 +1,51 @@
 import moment from 'moment'
 
+const MIN_INTERVAL_SECOND = 5
+const MIN_INTERVAL_UNIT = `${MIN_INTERVAL_SECOND}s`
+const MIN_SPAN = 10
+
 export const normalizeInterval = bucketInterval => {
     // interval = max(5, min(bucketIntervak, 60))
     const regex = /(\d+)(.*)/
     const interval = regex.exec(bucketInterval)
-    if (!interval||!interval.length) {
-        return '5s'
+    if (!interval) {
+        return MIN_INTERVAL_UNIT
     }
 
-    try {
-        const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
-        const normalized = Math.max(
-            5,
-            moment.duration(
-                Math.min(
-                    duration,
-                    60
-                ),
-                's'
-            ).asSeconds()
-        )
-        return `${normalized}s`
-    } catch (e) {
-        console.error(`parsing interval ${bucketInterval} failed`, e)
-        return '5s'
+    const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
+    if (!duration) {
+        return MIN_INTERVAL_UNIT
     }
+
+    const normalized = Math.max(
+        MIN_INTERVAL_SECOND,
+        Math.min(
+            duration,
+            60
+        )
+    )
+    return `${normalized}s`
 }
 
 export const normalizeSpan = bucketInterval => {
     // span = min(10, (2h/bucketInterval))
     const regex = /(\d+)(.*)/
     const interval = regex.exec(bucketInterval)
-    if (!interval||!interval.length) {
-        return 10
+    if (!interval) {
+        return MIN_SPAN
     }
 
-    try {
-        const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
-        return Math.ceil(
-            Math.min(
-                10,
-                moment.duration(
-                    moment.duration(2, 'h').asSeconds()/duration,
-                    's'
-                ).asSeconds()
-            )
-        )
-    } catch (e) {
-        console.error(`parsing span ${bucketInterval} failed`, e)
-        return 10
+    const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
+    if (!duration) {
+        return MIN_SPAN
     }
+
+    return Math.ceil(
+        Math.max(
+            MIN_SPAN,
+            7200/duration
+        )
+    )
 }
 
 export const normalizeFeatureDefault = fill => {

--- a/ui/src/loudml/utils/model.js
+++ b/ui/src/loudml/utils/model.js
@@ -1,20 +1,55 @@
 import moment from 'moment'
 
 export const normalizeInterval = bucketInterval => {
+    // interval = max(5, min(bucketIntervak, 60))
     const regex = /(\d+)(.*)/
     const interval = regex.exec(bucketInterval)
-    const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
-    const normalized = Math.max(
-        5,
-        moment.duration(
+    if (!interval||!interval.length) {
+        return '5s'
+    }
+
+    try {
+        const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
+        const normalized = Math.max(
+            5,
+            moment.duration(
+                Math.min(
+                    duration,
+                    60
+                ),
+                's'
+            ).asSeconds()
+        )
+        return `${normalized}s`
+    } catch (e) {
+        console.error(`parsing interval ${bucketInterval} failed`, e)
+        return '5s'
+    }
+}
+
+export const normalizeSpan = bucketInterval => {
+    // span = min(10, (2h/bucketInterval))
+    const regex = /(\d+)(.*)/
+    const interval = regex.exec(bucketInterval)
+    if (!interval||!interval.length) {
+        return 10
+    }
+
+    try {
+        const duration = moment.duration(Number.parseInt(interval[1], 10), interval[2]).asSeconds()
+        return Math.ceil(
             Math.min(
-                duration,
-                60
-            ),
-            's'
-        ).asSeconds()
-    )
-    return `${normalized}s`
+                10,
+                moment.duration(
+                    moment.duration(2, 'h').asSeconds()/duration,
+                    's'
+                ).asSeconds()
+            )
+        )
+    } catch (e) {
+        console.error(`parsing span ${bucketInterval} failed`, e)
+        return 10
+    }
 }
 
 export const normalizeFeatureDefault = fill => {

--- a/ui/src/loudml/utils/model.js
+++ b/ui/src/loudml/utils/model.js
@@ -1,8 +1,11 @@
 import moment from 'moment'
 
 const MIN_INTERVAL_SECOND = 5
-const MIN_INTERVAL_UNIT = `${MIN_INTERVAL_SECOND}s`
-const MIN_SPAN = 10
+export const MIN_INTERVAL_UNIT = `${MIN_INTERVAL_SECOND}s`
+const MAX_INTERVAL_SECOND = 60
+export const MAX_INTERVAL_UNIT = `${MAX_INTERVAL_SECOND}s`
+export const MIN_SPAN = 10
+export const MAX_SPAN = 100
 
 export const normalizeInterval = bucketInterval => {
     // interval = max(5, min(bucketIntervak, 60))
@@ -21,14 +24,14 @@ export const normalizeInterval = bucketInterval => {
         MIN_INTERVAL_SECOND,
         Math.min(
             duration,
-            60
+            MAX_INTERVAL_SECOND
         )
     )
     return `${normalized}s`
 }
 
 export const normalizeSpan = bucketInterval => {
-    // span = min(10, (2h/bucketInterval))
+    // span = max(10, min(24h/bucketInterval, 100))
     const regex = /(\d+)(.*)/
     const interval = regex.exec(bucketInterval)
     if (!interval) {
@@ -40,12 +43,7 @@ export const normalizeSpan = bucketInterval => {
         return MIN_SPAN
     }
 
-    return Math.ceil(
-        Math.max(
-            MIN_SPAN,
-            7200/duration
-        )
-    )
+    return Math.max(MIN_SPAN, Math.min(Math.ceil(86400/duration), MAX_SPAN))
 }
 
 export const normalizeFeatureDefault = fill => {

--- a/ui/test/loudml/utils/model.test.js
+++ b/ui/test/loudml/utils/model.test.js
@@ -1,34 +1,43 @@
-import {normalizeInterval, normalizeSpan} from 'src/loudml/utils/model'
+import {
+    normalizeInterval,
+    normalizeSpan,
+    MIN_INTERVAL_UNIT,
+    MAX_INTERVAL_UNIT,
+    MIN_SPAN,
+    MAX_SPAN
+} from 'src/loudml/utils/model'
 
 describe('Loudml.Utils.Model', () => {
     describe('normalizeInterval', () => {
-        const MIN_INTERVAL = '5s'
-        const MAX_INTERVAL = '60s'
+        // const MIN_INTERVAL = '5s'
+        // const MAX_INTERVAL = '60s'
 
-        it(`returns ${MIN_INTERVAL} if no explicit interval`, () => {
-            expect(normalizeInterval(null)).toEqual(MIN_INTERVAL)
+        it(`returns ${MIN_INTERVAL_UNIT} if no explicit interval`, () => {
+            expect(normalizeInterval(null)).toEqual(MIN_INTERVAL_UNIT)
         })
-        it(`returns ${MIN_INTERVAL} if parsing interval failed`, () => {
+        it(`returns ${MIN_INTERVAL_UNIT} if parsing interval failed`, () => {
             const interval = '5-'
-            expect(normalizeInterval(interval)).toEqual(MIN_INTERVAL)
+            expect(normalizeInterval(interval)).toEqual(MIN_INTERVAL_UNIT)
         })
-        it(`returns ${MAX_INTERVAL} if interval greater than ${MAX_INTERVAL}`, () => {
+        it(`returns ${MAX_INTERVAL_UNIT} if interval greater than ${MAX_INTERVAL_UNIT}`, () => {
             const interval = '2m'
-            expect(normalizeInterval(interval)).toEqual(MAX_INTERVAL)
+            expect(normalizeInterval(interval)).toEqual(MAX_INTERVAL_UNIT)
         })
-        it(`returns interval if between ${MIN_INTERVAL} and ${MAX_INTERVAL}`, () => {
+        it(`returns interval if between ${MIN_INTERVAL_UNIT} and ${MAX_INTERVAL_UNIT}`, () => {
             const interval = '25s'
             expect(normalizeInterval(interval)).toEqual(interval)
         })
-        it(`returns ${MIN_INTERVAL} if interval less than ${MIN_INTERVAL}`, () => {
+        it(`returns ${MIN_INTERVAL_UNIT} if interval less than ${MIN_INTERVAL_UNIT}`, () => {
             const interval = '4s'
-            expect(normalizeInterval(interval)).toEqual(MIN_INTERVAL)
+            expect(normalizeInterval(interval)).toEqual(MIN_INTERVAL_UNIT)
         })
     })
 
     describe('normalizeSpan', () => {
-        const MIN_SPAN = 10
-        const SPAN_THRESHOLD = '12m'
+        // const MIN_SPAN = 10
+        const MIN_SPAN_THRESHOLD = '864s'
+        const MAX_SPAN_THRESHOLD = '8640s'
+        const SPAN_UNIT = '8000s'
 
         it(`returns ${MIN_SPAN} if no explicit interval`, () => {
             expect(normalizeSpan(null)).toEqual(MIN_SPAN)
@@ -37,14 +46,19 @@ describe('Loudml.Utils.Model', () => {
             const interval = '5-'
             expect(normalizeSpan(interval)).toEqual(MIN_SPAN)
         })
-        it(`returns ${MIN_SPAN} if interval less than ${SPAN_THRESHOLD}`, () => {
-            const interval = '13m'
-            expect(normalizeSpan(interval)).toEqual(MIN_SPAN)
+        it(`returns ${MAX_SPAN} if interval less than ${MIN_SPAN_THRESHOLD}`, () => {
+            const interval = '800s'
+            expect(normalizeSpan(interval)).toEqual(MAX_SPAN)
         })
-        it(`returns interval if interval greater than ${SPAN_THRESHOLD}`, () => {
-            const interval = '11m'
+        it(`returns ${MIN_SPAN} if interval greater than ${MAX_SPAN_THRESHOLD}`, () => {
+            const interval = '9000s'
             const normalized = normalizeSpan(interval)
-            expect(normalized).toBeGreaterThan(MIN_SPAN)
+            expect(normalized).toEqual(MIN_SPAN)
+        })
+        it(`returns interval if between ${MIN_SPAN_THRESHOLD} and ${MAX_SPAN_THRESHOLD}`, () => {
+            const normalized = normalizeSpan(SPAN_UNIT)
+            expect(normalized).toBeGreaterThanOrEqual(MIN_SPAN)
+            expect(normalized).toBeLessThanOrEqual(MAX_SPAN)
         })
     })
 

--- a/ui/test/loudml/utils/model.test.js
+++ b/ui/test/loudml/utils/model.test.js
@@ -1,5 +1,4 @@
 import {normalizeInterval, normalizeSpan} from 'src/loudml/utils/model'
-import moment from 'moment'
 
 describe('Loudml.Utils.Model', () => {
     describe('normalizeInterval', () => {
@@ -39,14 +38,13 @@ describe('Loudml.Utils.Model', () => {
             expect(normalizeSpan(interval)).toEqual(MIN_SPAN)
         })
         it(`returns ${MIN_SPAN} if interval less than ${SPAN_THRESHOLD}`, () => {
-            const interval = '11m'
+            const interval = '13m'
             expect(normalizeSpan(interval)).toEqual(MIN_SPAN)
         })
         it(`returns interval if interval greater than ${SPAN_THRESHOLD}`, () => {
-            const interval = '13m'
+            const interval = '11m'
             const normalized = normalizeSpan(interval)
-            const expected = moment.duration(Number.parseInt(normalized, 10), 's').asSeconds()    // Math.ceil(9.23076923076923)
-            expect(expected).toBeLessThanOrEqual(MIN_SPAN)
+            expect(normalized).toBeGreaterThan(MIN_SPAN)
         })
     })
 

--- a/ui/test/loudml/utils/model.test.js
+++ b/ui/test/loudml/utils/model.test.js
@@ -1,0 +1,53 @@
+import {normalizeInterval, normalizeSpan} from 'src/loudml/utils/model'
+import moment from 'moment'
+
+describe('Loudml.Utils.Model', () => {
+    describe('normalizeInterval', () => {
+        const MIN_INTERVAL = '5s'
+        const MAX_INTERVAL = '60s'
+
+        it(`returns ${MIN_INTERVAL} if no explicit interval`, () => {
+            expect(normalizeInterval(null)).toEqual(MIN_INTERVAL)
+        })
+        it(`returns ${MIN_INTERVAL} if parsing interval failed`, () => {
+            const interval = '5-'
+            expect(normalizeInterval(interval)).toEqual(MIN_INTERVAL)
+        })
+        it(`returns ${MAX_INTERVAL} if interval greater than ${MAX_INTERVAL}`, () => {
+            const interval = '2m'
+            expect(normalizeInterval(interval)).toEqual(MAX_INTERVAL)
+        })
+        it(`returns interval if between ${MIN_INTERVAL} and ${MAX_INTERVAL}`, () => {
+            const interval = '25s'
+            expect(normalizeInterval(interval)).toEqual(interval)
+        })
+        it(`returns ${MIN_INTERVAL} if interval less than ${MIN_INTERVAL}`, () => {
+            const interval = '4s'
+            expect(normalizeInterval(interval)).toEqual(MIN_INTERVAL)
+        })
+    })
+
+    describe('normalizeSpan', () => {
+        const MIN_SPAN = 10
+        const SPAN_THRESHOLD = '12m'
+
+        it(`returns ${MIN_SPAN} if no explicit interval`, () => {
+            expect(normalizeSpan(null)).toEqual(MIN_SPAN)
+        })
+        it(`returns ${MIN_SPAN} if parsing interval failed`, () => {
+            const interval = '5-'
+            expect(normalizeSpan(interval)).toEqual(MIN_SPAN)
+        })
+        it(`returns ${MIN_SPAN} if interval less than ${SPAN_THRESHOLD}`, () => {
+            const interval = '11m'
+            expect(normalizeSpan(interval)).toEqual(MIN_SPAN)
+        })
+        it(`returns interval if interval greater than ${SPAN_THRESHOLD}`, () => {
+            const interval = '13m'
+            const normalized = normalizeSpan(interval)
+            const expected = moment.duration(Number.parseInt(normalized, 10), 's').asSeconds()    // Math.ceil(9.23076923076923)
+            expect(expected).toBeLessThanOrEqual(MIN_SPAN)
+        })
+    })
+
+})


### PR DESCRIPTION
Closes #

Normalize span value for 1-Click ML
Span default value is 10
Apply formula max(10, 2h/time) where time is the group by value selected in the dataexplorer

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
