### PR TITLE
tags (key/values) in 1-Click model name

### DIFF
--- a/ui/src/loudml/CHANGELOG.md
+++ b/ui/src/loudml/CHANGELOG.md
@@ -7,6 +7,7 @@
 1.  [#23](https://github.com/regel/chronograf/pull/23): Scores and Transform settings in Feature panel
 1.  [#24](https://github.com/regel/chronograf/pull/24): Datasink
 1.  [#28](https://github.com/regel/chronograf/pull/28): Unserialized Features in model
+1.  [#38](https://github.com/regel/chronograf/pull/38): tags (key/values) in 1-Click model name
 
 ### UI Improvements
 

--- a/ui/src/loudml/components/OneClickML.js
+++ b/ui/src/loudml/components/OneClickML.js
@@ -113,6 +113,12 @@ const checkTags = (tags) => {
     return Object.values(tags).some(v => v.length>1) === false
 }
 
+const tagsToName = (tags) => {
+    return Object.entries(tags)
+        .map(([k, v]) => (`${k}_${v.map(i => (i.replace(/[.-]/g, '_'))).join('_')}`))
+        .join('_')
+}
+
 class OneClickML extends Component {
     constructor(props) {
         super(props)
@@ -175,6 +181,7 @@ class OneClickML extends Component {
                 measurement,
                 fields,
                 groupBy: {time},
+                tags,
             }
         } = this.props
         return [
@@ -182,6 +189,7 @@ class OneClickML extends Component {
             measurement,
             fields[0].value,
             fields[0].args[0].value,
+            tagsToName(tags),
             time
         ].join('_')
     }


### PR DESCRIPTION
Closes #

Selected tag (key/value) for 1-Click ML is now in the model name
Multiple models differing only in the value of the selected tag can not be created (err Model exists)
Add tag key and value(s) in the model name solves the problem

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass (manual)
