### PR TITLE
retention policy value from Loud ML datasource

### DIFF
--- a/ui/src/loudml/CHANGELOG.md
+++ b/ui/src/loudml/CHANGELOG.md
@@ -7,6 +7,7 @@
 1.  [#23](https://github.com/regel/chronograf/pull/23): Scores and Transform settings in Feature panel
 1.  [#24](https://github.com/regel/chronograf/pull/24): Datasink
 1.  [#28](https://github.com/regel/chronograf/pull/28): Unserialized Features in model
+1.  [#39](https://github.com/regel/chronograf/pull/39): retention policy value from Loud ML datasource
 
 ### UI Improvements
 

--- a/ui/src/loudml/components/OneClickML.js
+++ b/ui/src/loudml/components/OneClickML.js
@@ -128,7 +128,8 @@ class OneClickML extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.settings.database !== prevProps.settings.database) {
+        if (this.props.settings.database !== prevProps.settings.database
+            ||this.props.settings.retentionPolicy !== prevProps.settings.retentionPolicy) {
             this._getDatasource();
         }
     }
@@ -162,9 +163,9 @@ class OneClickML extends Component {
     }
 
     _getDatasource = async () => {
-        const {settings: {database}} = this.props
+        const {settings: {database, retentionPolicy}} = this.props
         const {data} = await getDatasources()
-        const datasource = data.find(d => d.database === database)
+        const datasource = data.find(d => d.database === database && d.retention_policy === retentionPolicy)
         this.setState({datasource: datasource&&datasource.name})
     }
 

--- a/ui/src/loudml/components/OneClickML.js
+++ b/ui/src/loudml/components/OneClickML.js
@@ -34,7 +34,7 @@ import {
     notifyModelTrainingFailed,
 } from 'src/loudml/actions/notifications'
 
-import {DEFAULT_MODEL} from 'src/loudml/constants'
+import {DEFAULT_MODEL, DEFAULT_LOUDML_RP} from 'src/loudml/constants'
 import {ANOMALY_HOOK} from 'src/loudml/constants/anomaly'
 
 const UNDEFINED_DATASOURCE = 'Unable to find LoudML datasource for selected database. Check configuration'
@@ -165,7 +165,7 @@ class OneClickML extends Component {
     _getDatasource = async () => {
         const {settings: {database, retentionPolicy}} = this.props
         const {data} = await getDatasources()
-        const datasource = data.find(d => d.database === database && d.retention_policy === retentionPolicy)
+        const datasource = data.find(d => d.database === database && (d.retention_policy||DEFAULT_LOUDML_RP) === retentionPolicy)
         this.setState({datasource: datasource&&datasource.name})
     }
 

--- a/ui/src/loudml/containers/LoudMLPage.js
+++ b/ui/src/loudml/containers/LoudMLPage.js
@@ -339,10 +339,10 @@ class LoudMLPage extends Component {
         this.stopJob(name, id)
     }
 
-    createPredictionDashboard = (model, source, database) => {
+    createPredictionDashboard = (model, source, datasource) => {
         const {settings: {name}} = model
         const cellName = `${name} prediction`
-        const queries = createQueryFromModel(model, source, database)
+        const queries = createQueryFromModel(model, source, datasource)
 
         const dashboard = {
             ...DEFAULT_ERROR_DASHBOARD,
@@ -358,10 +358,10 @@ class LoudMLPage extends Component {
         return createDashboard(dashboard)
     }
 
-    updatePredictionDashboard = (dashboard, model, source, database) => {
+    updatePredictionDashboard = (dashboard, model, source, datasource) => {
         const {settings: {name}} = model
         const cellName = `${name} prediction`
-        const queries = createQueryFromModel(model, source, database)
+        const queries = createQueryFromModel(model, source, datasource)
 
         const cell = dashboard.cells.find(item => item.name === cellName)
         if (cell===undefined) {
@@ -405,7 +405,7 @@ class LoudMLPage extends Component {
             const datasource = data.find(d => d.name === settings.default_datasource)
             const {data: {sources}} = await getSources()
             const source = findSource(sources, datasource)
-            await this.createPredictionDashboard(model, source, datasource.database)
+            await this.createPredictionDashboard(model, source, datasource)
             notify(notifyDashboardCreated(settings.name))
             this.getDashboards()    // update for Dashboard dropdown
         } catch (error) {
@@ -423,7 +423,7 @@ class LoudMLPage extends Component {
             const datasource = data.find(d => d.name === settings.default_datasource)
             const {data: {sources}} = await getSources()
             const source = findSource(sources, datasource)
-            await this.updatePredictionDashboard(dashboard, model, source, datasource.database)
+            await this.updatePredictionDashboard(dashboard, model, source, datasource)
             notify(notifyDashboardCellCreated(settings.name))
         } catch (error) {
             console.error(error)

--- a/ui/src/loudml/utils/query.js
+++ b/ui/src/loudml/utils/query.js
@@ -5,7 +5,6 @@ import FeaturesUtils from 'src/loudml/components/FeaturesUtils'
 import { DEFAULT_LOUDML_RP } from 'src/loudml/constants';
 
 const QUERY_CONFIG = {
-    retentionPolicy: DEFAULT_LOUDML_RP,
     areTagsAccepted: true,
     rawText: null,
     range: {
@@ -63,14 +62,15 @@ const getTags = feature => {
     }, {})
 }
 
-const createErrorQueryConfig = (prefix, model, database) => {
+const createErrorQueryConfig = (prefix, model, datasource) => {
     const {name, features} = model
     const feature = features[0]
 
     return {
         ...QUERY_CONFIG,
         fields: createErrorQueryFields(prefix, model),
-        database,
+        database: datasource.database,
+        retentionPolicy: datasource.retention_policy||DEFAULT_LOUDML_RP,
         measurement: `prediction_${name}`,
         tags: getTags(feature),
         fill: null,
@@ -81,7 +81,7 @@ const createErrorQueryConfig = (prefix, model, database) => {
     }
 }
 
-const createModelQueryConfig = (model, database) => {
+const createModelQueryConfig = (model, datasource) => {
     const {features} = model
     const feature = features[0]
     const measurement = feature.measurement
@@ -89,7 +89,8 @@ const createModelQueryConfig = (model, database) => {
     return {
         ...QUERY_CONFIG,
         fields: createModelQueryFields(model),
-        database,
+        database: datasource.database,
+        retentionPolicy: datasource.retention_policy||DEFAULT_LOUDML_RP,
         measurement,
         tags: getTags(feature),
         fill: feature.default,
@@ -100,7 +101,7 @@ const createModelQueryConfig = (model, database) => {
     }
 }
 
-export const createQueryFromModel = (model, source, database) => {
+export const createQueryFromModel = (model, source, datasource) => {
     const {settings} = model
     const {links: {self}} = source
     
@@ -116,16 +117,16 @@ export const createQueryFromModel = (model, source, database) => {
         { queryConfig: createErrorQueryConfig(
             'lower',
             m,
-            database),
+            datasource),
         },
         { queryConfig: createModelQueryConfig(
             m,
-            database),
+            datasource),
         },
         { queryConfig: createErrorQueryConfig(
             'upper',
             m,
-            database),
+            datasource),
         },
     ]
     return [{


### PR DESCRIPTION
Closes #20

Manage retention policy for 1-Click ML (model creation) and Prediction Dashboard (new/view/add to...)
Retention policy was set to "autogen" default value
Since Loud ML 1.4.3 datasource definition has been extended with retention policy key. This value is now used to get right database

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass (manual)
